### PR TITLE
BAH-4203 | Add. Bump OpenMRS Core Version v2.5.12 To v2.6.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	</modules>
 
 	<properties>
-		<openmrsPlatformVersion>2.5.12</openmrsPlatformVersion>
+		<openmrsPlatformVersion>2.6.15</openmrsPlatformVersion>
 		<springVersion>5.2.14.RELEASE</springVersion>
 		<junitVersion>4.13</junitVersion>
 		<powerMockVersion>2.0.7</powerMockVersion>
@@ -45,7 +45,7 @@
 		<argLine>-Xmx1024m</argLine>
 		<jacocoVersion>0.7.9</jacocoVersion>
 		<lombokVersion>1.18.26</lombokVersion>
-		<openmrsFhir2Version>2.1.0</openmrsFhir2Version>
+		<openmrsFhir2Version>2.5.0</openmrsFhir2Version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
__JIRA__ → [BAH-4203](https://bahmni.atlassian.net/browse/BAH-4203)

Upgraded OpenMRS dependencies to align with the latest stable releases and improve compatibility.

**Changes**
- OpenMRS Core: 2.5.12 → 2.6.15
- OpenMRS FHIR2 Module: 2.1.0 → 2.5.0

**Context**
These upgrades bring in the latest bug fixes, performance improvements, and enhanced FHIR support.