### PR TITLE
BAH-4503 | Refactor. Define models through Hibernate Entity mappings in XML

### DIFF
--- a/api/src/main/java/org/openmrs/module/fhir2/apiext/impl/FhirMedicationAdministrationServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/fhir2/apiext/impl/FhirMedicationAdministrationServiceImpl.java
@@ -22,6 +22,7 @@ import org.openmrs.module.fhir2.api.search.SearchQueryInclude;
 import org.openmrs.module.fhir2.apiext.search.param.MedicationAdministrationSearchParams;
 import org.openmrs.module.fhir2.apiext.translators.MedicationAdministrationTranslator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -36,9 +37,11 @@ public class FhirMedicationAdministrationServiceImpl extends BaseFhirService<Med
 	private FhirMedicationAdministrationDao dao;
 
 	@Autowired
+	@Lazy
 	private SearchQueryInclude<MedicationAdministration> searchQueryInclude;
 
 	@Autowired
+	@Lazy
 	private SearchQuery<org.openmrs.module.ipd.api.model.MedicationAdministration,MedicationAdministration,FhirMedicationAdministrationDao<org.openmrs.module.ipd.api.model.MedicationAdministration>, MedicationAdministrationTranslator<org.openmrs.module.ipd.api.model.MedicationAdministration>, SearchQueryInclude<MedicationAdministration>> searchQuery;
 
 	@Override

--- a/api/src/main/java/org/openmrs/module/ipd/api/model/MedicationAdministration.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/model/MedicationAdministration.java
@@ -11,13 +11,12 @@ package org.openmrs.module.ipd.api.model;
 
 import org.openmrs.*;
 
-import javax.persistence.*;
 import java.util.Date;
 import java.util.Objects;
 import java.util.Set;
 
 /**
- * The MedicationAdministration class records detailed information about the provision of a supply of a medication 
+ * The MedicationAdministration class records detailed information about the provision of a supply of a medication
  * with the intention that it is subsequently consumed by a patient (usually in response to a prescription).
  *
  * @see <a href="https://www.hl7.org/fhir/medicationadministration.html">
@@ -25,136 +24,38 @@ import java.util.Set;
  *     	</a>
  * @since 2.5.12
  */
-@Entity
-@Table(name = "medication_administration")
 public class MedicationAdministration extends BaseFormRecordableOpenmrsData {
 
 	private static final long serialVersionUID = 1L;
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "medication_administration_id")
 	private Integer medicationAdministrationId;
 
-	/**
-	 * FHIR:subject
-	 * Patient for whom the medication is intended
-	 */
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "patient_id")
 	private Patient patient;
 
-	/**
-	 * FHIR:context
-	 * Encounter when the dispensing event occurred
-	 */
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "encounter_id")
 	private Encounter encounter;
 
-	/**
-	 * FHIR:medication.reference(Medication)
-	 * Corresponds to drugOrder.drug
-	 */
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "drug_id")
 	private Drug drug;
 
-	/**
-	 * FHIR:performer
-	 * @see <a href="https://www.hl7.org/fhir/medicationadministration-definitions.html#MedicationAdministration.performer">
-	 *     	https://www.hl7.org/fhir/medicationadministration-definitions.html#MedicationAdministration.performer
-	 *     </a>specification, It should be assumed that the actor can be the performer, verifier or witness of the medication administration.
-	 */
-	@OneToMany(cascade = CascadeType.ALL)
-	@JoinColumn(name = "medication_administration_id")
 	private Set<MedicationAdministrationPerformer> performers;
 
-	/**
-	 * FHIR:request
-	 * The drug order that led to this administration event;
-	 * note that request maps to a "MedicationRequest" FHIR resource
-	 */
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "drug_order_id")
 	private DrugOrder drugOrder;
 
-	/**
-	 * FHIR:status
-	 * @see <a href="https://www.hl7.org/fhir/valueset-medicationadministration-status.html">
-	 *     		https://www.hl7.org/fhir/valueset-medicationadministration-status.html
-	 *     	</a>
-	 * i.e. in-progress, cancelled, on-hold, completed, entered-in-error, stopped, declined, unknown
-	 */
-	@Column(nullable = false)
-	@Enumerated(EnumType.STRING)
 	private org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus status;
 
-	/**
-	 * FHIR:statusReason.statusReasonCodeableConcept
-	 * @see <a href="https://www.hl7.org/fhir/valueset-medicationadministration-status-reason.html">
-	 *     		https://www.hl7.org/fhir/valueset-medicationadministration-status-reason.html
-	 *     	</a>
-	 * i.e "Stock Out"
-	 */
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "status_reason")
 	private Concept statusReason;
 
-	/**
-	 * FHIR:effective.effectiveDateTime
-	 * Time when the medication was administered
-	 */
-	@Column(name = "administered_date_time")
 	private Date administeredDateTime;
 
-	/**
-	 * FHIR:dosage.text
-	 * The dosage instructions should reflect the dosage of the medication that was administered.
-	 */
-	@Column(name = "dosing_instructions", length=65535)
 	private String dosingInstructions;
 
-	/**
-	 * FHIR:dosage.dose.value
-	 * Numbered Value of the amount of the medication given at one administration event
-	 */
-	@Column(name = "dose")
 	private Double dose;
 
-	/**
-	 * FHIR:dosage.dose.unit
-	 * Units of the amount of the medication given at one administration event. For example, mg, mL, etc.
-	 */
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "dose_units")
 	private Concept doseUnits;
-	
-	/**
-	 * FHIR:dosage.route
-	 * Path of substance into body, For example, topical, intravenous, etc.
-	 */
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "route")
+
 	private Concept route;
 
-	/**
-	 * FHIR:dosage.site
-	 * Body site administered to, For example, left arm, etc.
-	 */
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "site")
 	private Concept site;
 
-	/**
-	 * FHIR:note
-	 * @see <a href="https://hl7.org/fhir/R4/datatypes.html#Annotation">
-	 *     	https://hl7.org/fhir/R4/datatypes.html#Annotation
-	 *     </a>
-	 * Notes or additional information about the medication administration.
-	 */
-	@OneToMany(cascade = CascadeType.ALL)
-	@JoinColumn(name = "medication_administration_id")
 	private Set<MedicationAdministrationNote> notes;
 
 

--- a/api/src/main/java/org/openmrs/module/ipd/api/model/MedicationAdministrationNote.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/model/MedicationAdministrationNote.java
@@ -11,7 +11,6 @@ package org.openmrs.module.ipd.api.model;
 
 import org.openmrs.*;
 
-import javax.persistence.*;
 import java.util.Date;
 
 /**
@@ -22,37 +21,16 @@ import java.util.Date;
  *     	</a>
  * @since 2.5.12
  */
-@Entity
-@Table(name = "medication_administration_note")
 public class MedicationAdministrationNote extends BaseOpenmrsData {
 
 	private static final long serialVersionUID = 1L;
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "medication_administration_note_id")
 	private Integer medicationAdministrationNoteId;
 
-	/**
-	 * FHIR:author
-	 * Who made the statement
-	 */
-	@OneToOne(optional = true)
-	@JoinColumn(name = "author_id")
 	private Provider author;
 
-	/**
-	 * FHIR:time
-	 * Time when the statement was recorded
-	 */
-	@Column(name = "recorded_time")
 	private Date recordedTime;
 
-	/**
-	 * FHIR:text
-	 * The statement - a text note associated with the annotation.
-	 */
-	@Column(name = "text", length=65535)
 	private String text;
 
 	public MedicationAdministrationNote() {

--- a/api/src/main/java/org/openmrs/module/ipd/api/model/MedicationAdministrationPerformer.java
+++ b/api/src/main/java/org/openmrs/module/ipd/api/model/MedicationAdministrationPerformer.java
@@ -11,8 +11,6 @@ package org.openmrs.module.ipd.api.model;
 
 import org.openmrs.*;
 
-import javax.persistence.*;
-
 /**
  * The MedicationAdministration class records detailed information about the provision of a supply of a medication
  * with the intention that it is subsequently consumed by a patient (usually in response to a prescription).
@@ -22,34 +20,14 @@ import javax.persistence.*;
  *     	</a>
  * @since 2.5.12
  */
-@Entity
-@Table(name = "medication_administration_performer")
 public class MedicationAdministrationPerformer extends BaseFormRecordableOpenmrsData {
 
 	private static final long serialVersionUID = 1L;
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "medication_administration_performer_id")
 	private Integer medicationAdministrationPerformerId;
 
-	/**
-	 * FHIR:actor
-	 * Indicates who or what performed the medication administration and how they were involved.
-	 */
-	@OneToOne(optional = false)
-	@JoinColumn(name = "actor_id")
 	private Provider actor;
 
-	/**
-	 * FHIR:function
-	 * @see <a href="https://hl7.org/fhir/R4/valueset-med-admin-perform-function.html">
-	 *     		https://hl7.org/fhir/R4/valueset-med-admin-perform-function.html
-	 *     	</a>
-	 * i.e. performer, verifier, witness
-	 */
-	@ManyToOne(optional = true)
-	@JoinColumn(name = "performer_function")
 	private Concept function;
 
 	public MedicationAdministrationPerformer() {

--- a/api/src/main/resources/MedicationAdministration.hbm.xml
+++ b/api/src/main/resources/MedicationAdministration.hbm.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.ipd.api.model">
+
+	<class name="MedicationAdministration" table="medication_administration">
+
+		<id name="medicationAdministrationId" type="int" column="medication_administration_id">
+			<generator class="identity" />
+		</id>
+
+		<property name="uuid" type="java.lang.String" column="uuid" length="38" unique="true" not-null="true" />
+
+		<many-to-one name="patient" class="org.openmrs.Patient" column="patient_id" />
+		<many-to-one name="encounter" class="org.openmrs.Encounter" column="encounter_id" />
+		<many-to-one name="drug" class="org.openmrs.Drug" column="drug_id" />
+		<many-to-one name="drugOrder" class="org.openmrs.DrugOrder" column="drug_order_id" />
+
+		<property name="status" column="status" not-null="true">
+			<type name="org.hibernate.type.EnumType">
+				<param name="enumClass">org.hl7.fhir.r4.model.MedicationAdministration$MedicationAdministrationStatus</param>
+				<param name="useNamed">true</param>
+			</type>
+		</property>
+
+		<many-to-one name="statusReason" class="org.openmrs.Concept" column="status_reason" />
+
+		<property name="administeredDateTime" type="java.util.Date" column="administered_date_time" />
+		<property name="dosingInstructions" type="java.lang.String" column="dosing_instructions" length="65535" />
+		<property name="dose" type="java.lang.Double" column="dose" />
+
+		<many-to-one name="doseUnits" class="org.openmrs.Concept" column="dose_units" />
+		<many-to-one name="route" class="org.openmrs.Concept" column="route" />
+		<many-to-one name="site" class="org.openmrs.Concept" column="site" />
+
+		<set name="performers" cascade="all">
+			<key column="medication_administration_id" />
+			<one-to-many class="MedicationAdministrationPerformer" />
+		</set>
+
+		<set name="notes" cascade="all">
+			<key column="medication_administration_id" />
+			<one-to-many class="MedicationAdministrationNote" />
+		</set>
+
+		<!-- BaseFormRecordableOpenmrsData fields -->
+		<property name="formNamespaceAndPath" type="java.lang.String" column="form_namespace_and_path" length="255" />
+
+		<!-- BaseChangeableOpenmrsData / BaseOpenmrsData fields -->
+		<many-to-one name="creator" class="org.openmrs.User" column="creator" not-null="true" />
+		<property name="dateCreated" type="java.util.Date" column="date_created" not-null="true" />
+		<many-to-one name="changedBy" class="org.openmrs.User" column="changed_by" />
+		<property name="dateChanged" type="java.util.Date" column="date_changed" />
+		<property name="voided" type="java.lang.Boolean" column="voided" not-null="true" />
+		<many-to-one name="voidedBy" class="org.openmrs.User" column="voided_by" />
+		<property name="dateVoided" type="java.util.Date" column="date_voided" />
+		<property name="voidReason" type="java.lang.String" column="void_reason" length="255" />
+
+	</class>
+
+</hibernate-mapping>

--- a/api/src/main/resources/MedicationAdministrationNote.hbm.xml
+++ b/api/src/main/resources/MedicationAdministrationNote.hbm.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.ipd.api.model">
+
+	<class name="MedicationAdministrationNote" table="medication_administration_note">
+
+		<id name="medicationAdministrationNoteId" type="int" column="medication_administration_note_id">
+			<generator class="identity" />
+		</id>
+
+		<property name="uuid" type="java.lang.String" column="uuid" length="38" unique="true" not-null="true" />
+
+		<many-to-one name="author" class="org.openmrs.Provider" column="author_id" />
+		<property name="recordedTime" type="java.util.Date" column="recorded_time" />
+		<property name="text" type="java.lang.String" column="text" length="65535" />
+
+		<!-- BaseOpenmrsData fields -->
+		<many-to-one name="creator" class="org.openmrs.User" column="creator" not-null="true" />
+		<property name="dateCreated" type="java.util.Date" column="date_created" not-null="true" />
+		<many-to-one name="changedBy" class="org.openmrs.User" column="changed_by" />
+		<property name="dateChanged" type="java.util.Date" column="date_changed" />
+		<property name="voided" type="java.lang.Boolean" column="voided" not-null="true" />
+		<many-to-one name="voidedBy" class="org.openmrs.User" column="voided_by" />
+		<property name="dateVoided" type="java.util.Date" column="date_voided" />
+		<property name="voidReason" type="java.lang.String" column="void_reason" length="255" />
+
+	</class>
+
+</hibernate-mapping>

--- a/api/src/main/resources/MedicationAdministrationPerformer.hbm.xml
+++ b/api/src/main/resources/MedicationAdministrationPerformer.hbm.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+		"-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+		"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.ipd.api.model">
+
+	<class name="MedicationAdministrationPerformer" table="medication_administration_performer">
+
+		<id name="medicationAdministrationPerformerId" type="int" column="medication_administration_performer_id">
+			<generator class="identity" />
+		</id>
+
+		<property name="uuid" type="java.lang.String" column="uuid" length="38" unique="true" not-null="true" />
+
+		<many-to-one name="actor" class="org.openmrs.Provider" column="actor_id" not-null="true" />
+		<many-to-one name="function" class="org.openmrs.Concept" column="performer_function" />
+
+		<!-- BaseFormRecordableOpenmrsData fields -->
+		<property name="formNamespaceAndPath" type="java.lang.String" column="form_namespace_and_path" length="255" />
+
+		<!-- BaseOpenmrsData fields -->
+		<many-to-one name="creator" class="org.openmrs.User" column="creator" not-null="true" />
+		<property name="dateCreated" type="java.util.Date" column="date_created" not-null="true" />
+		<many-to-one name="changedBy" class="org.openmrs.User" column="changed_by" />
+		<property name="dateChanged" type="java.util.Date" column="date_changed" />
+		<property name="voided" type="java.lang.Boolean" column="voided" not-null="true" />
+		<many-to-one name="voidedBy" class="org.openmrs.User" column="voided_by" />
+		<property name="dateVoided" type="java.util.Date" column="date_voided" />
+		<property name="voidReason" type="java.lang.String" column="void_reason" length="255" />
+
+	</class>
+
+</hibernate-mapping>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -5,8 +5,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <context:component-scan base-package="org.openmrs.module.fhir2.apiext"/>
     <context:annotation-config />

--- a/api/src/test/java/org/openmrs/module/fhir2/apiext/dao/impl/MedicationAdministrationHibernateIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/apiext/dao/impl/MedicationAdministrationHibernateIntegrationTest.java
@@ -31,74 +31,28 @@ import org.openmrs.module.ipd.api.model.MedicationAdministrationPerformer;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 import org.springframework.orm.hibernate5.LocalSessionFactoryBean;
 
-/**
- * Standalone integration test — no Spring application context — verifying that
- * {@link MedicationAdministration}, together with its cascaded
- * {@link MedicationAdministrationPerformer} and {@link MedicationAdministrationNote} collections,
- * can be persisted and reloaded through Hibernate using the module's HBM XML mappings.
- *
- * <h3>Why standalone?</h3>
- * The OpenMRS test application context (loaded by {@code BaseContextSensitiveTest}) scans
- * {@code org.openmrs.*} and instantiates all fhir2-api {@code @Component} beans. Those beans
- * depend on {@code SearchQueryInclude<T>} generic-typed beans that are only available in the full
- * FHIR2 OMOD context (not in an isolated test classpath). Bootstrapping the Hibernate
- * {@link SessionFactory} directly — using Spring's {@link LocalSessionFactoryBean} for its JPA
- * package-scan capability — sidesteps that issue entirely without modifying any production bean
- * definitions.
- *
- * <h3>Schema and test data</h3>
- * A fresh H2 in-memory database is created once per test class. The URL includes
- * {@code REFERENTIAL_INTEGRITY=FALSE} so that stub FK references ({@code User} and
- * {@code Provider} proxies backed by hard-coded IDs) can be written without seeding the entire
- * OpenMRS reference table set. {@code hbm2ddl.auto=create} generates the full schema from the
- * combined HBM and JPA entity mappings automatically.
- *
- * <h3>Round-trip being tested</h3>
- * <ol>
- *   <li>Build entity graph (parent + one performer + one note).</li>
- *   <li>Persist via {@code session.save()} — {@code cascade="all"} in the HBM XML saves the
- *       children.</li>
- *   <li>Flush SQL to the DB and clear the first-level cache.</li>
- *   <li>Reload by generated PK and assert every mapped field.</li>
- * </ol>
- */
 public class MedicationAdministrationHibernateIntegrationTest {
 
 	private static SessionFactory sessionFactory;
 
 	@BeforeClass
 	public static void buildSessionFactory() throws Exception {
-		/*
-		 * H2 in-memory data source.  REFERENTIAL_INTEGRITY=FALSE lets us use
-		 * Hibernate proxy stubs for User and Provider without inserting those rows.
-		 */
 		SimpleDriverDataSource dataSource = new SimpleDriverDataSource(
 		        new org.h2.Driver(),
 		        "jdbc:h2:mem:med_admin_mapping_test;DB_CLOSE_DELAY=-1;REFERENTIAL_INTEGRITY=FALSE",
 		        "sa", "");
 
-		/*
-		 * LocalSessionFactoryBean gives us Spring's packagesToScan capability so that
-		 * JPA-annotated OpenMRS entities (Encounter, Allergy, Condition …) are
-		 * registered alongside the HBM-mapped ones — exactly as the production
-		 * HibernateSessionFactoryBean does in TestingApplicationContext.xml.
-		 * No Spring application context is started, so no fhir2 service beans are
-		 * instantiated and no FHIR2 infrastructure is needed.
-		 */
 		LocalSessionFactoryBean factoryBean = new LocalSessionFactoryBean();
 		factoryBean.setDataSource(dataSource);
 
-		// Core OpenMRS HBM mappings (Patient, Drug, Order, Concept, User, Provider …)
 		factoryBean.setConfigLocations(
 		        new org.springframework.core.io.ClassPathResource("hibernate.cfg.xml"));
 
-		// Module-specific mappings under test
 		factoryBean.setMappingResources(
 		        "MedicationAdministration.hbm.xml",
 		        "MedicationAdministrationPerformer.hbm.xml",
 		        "MedicationAdministrationNote.hbm.xml");
 
-		// JPA-annotated OpenMRS entities (Encounter, Allergy, Condition …)
 		factoryBean.setPackagesToScan("org.openmrs");
 
 		Properties hibernateProps = new Properties();
@@ -108,7 +62,6 @@ public class MedicationAdministrationHibernateIntegrationTest {
 		hibernateProps.setProperty("hibernate.cache.use_second_level_cache", "false");
 		hibernateProps.setProperty("hibernate.cache.use_query_cache", "false");
 		hibernateProps.setProperty("hibernate.search.autoregister_listeners", "false");
-		// Required for OpenMRS identity-generator mappings (Hibernate 5 default changed)
 		hibernateProps.setProperty("hibernate.id.new_generator_mappings", "false");
 		factoryBean.setHibernateProperties(hibernateProps);
 
@@ -128,22 +81,15 @@ public class MedicationAdministrationHibernateIntegrationTest {
 		Session session = sessionFactory.openSession();
 		Transaction tx = session.beginTransaction();
 		try {
-			// ── Stub FK references ─────────────────────────────────────────────────
-			// session.load() returns a Hibernate proxy carrying the given PK.
-			// Hibernate writes only the PK to the FK column; it never loads the actual
-			// row, so these stubs work even though the user / provider tables are empty
-			// (REFERENTIAL_INTEGRITY=FALSE on the H2 URL).
 			User creator = session.load(User.class, 1);
 			Provider provider = session.load(Provider.class, 1);
 
-			// ── Build performer ────────────────────────────────────────────────────
 			MedicationAdministrationPerformer performer = new MedicationAdministrationPerformer();
 			performer.setActor(provider);
 			performer.setCreator(creator);
 			performer.setDateCreated(new Date());
 			performer.setVoided(false);
 
-			// ── Build note ─────────────────────────────────────────────────────────
 			MedicationAdministrationNote note = new MedicationAdministrationNote();
 			note.setAuthor(provider);
 			note.setRecordedTime(new Date());
@@ -152,7 +98,6 @@ public class MedicationAdministrationHibernateIntegrationTest {
 			note.setDateCreated(new Date());
 			note.setVoided(false);
 
-			// ── Build parent entity ────────────────────────────────────────────────
 			MedicationAdministration medAdmin = new MedicationAdministration();
 			medAdmin.setStatus(
 			    org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.COMPLETED);
@@ -165,19 +110,14 @@ public class MedicationAdministrationHibernateIntegrationTest {
 			medAdmin.setDateCreated(new Date());
 			medAdmin.setVoided(false);
 
-			// ── Persist (cascade="all" saves performer and note automatically) ─────
 			Integer savedId = (Integer) session.save(medAdmin);
 
-			// Flush SQL to the DB, then evict the first-level cache so the subsequent
-			// get() must issue a SELECT rather than returning the in-memory instance.
 			session.flush();
 			session.clear();
 
-			// ── Reload from the database ───────────────────────────────────────────
 			MedicationAdministration retrieved =
 			        session.get(MedicationAdministration.class, savedId);
 
-			// ── Assert: top-level scalar fields ────────────────────────────────────
 			assertNotNull("Reloaded entity must not be null", retrieved);
 			assertNotNull("UUID must have been auto-generated and persisted",
 			    retrieved.getUuid());
@@ -189,7 +129,6 @@ public class MedicationAdministrationHibernateIntegrationTest {
 			assertEquals("DosingInstructions round-trip failed",
 			    "Take with food", retrieved.getDosingInstructions());
 
-			// ── Assert: performers collection (one-to-many, cascade="all") ─────────
 			assertNotNull("Performers collection must not be null after reload",
 			    retrieved.getPerformers());
 			assertEquals("Exactly one performer must be reloaded",
@@ -198,12 +137,9 @@ public class MedicationAdministrationHibernateIntegrationTest {
 			        retrieved.getPerformers().iterator().next();
 			assertNotNull("Performer PK must be assigned by the identity generator",
 			    retrievedPerformer.getMedicationAdministrationPerformerId());
-			// getProviderId() reads the PK from the Hibernate proxy identity without
-			// triggering a DB load, confirming the actor_id FK column was written correctly.
 			assertEquals("Performer actor_id FK must match the stub provider id",
 			    Integer.valueOf(1), retrievedPerformer.getActor().getProviderId());
 
-			// ── Assert: notes collection (one-to-many, cascade="all") ─────────────
 			assertNotNull("Notes collection must not be null after reload",
 			    retrieved.getNotes());
 			assertEquals("Exactly one note must be reloaded",

--- a/api/src/test/java/org/openmrs/module/fhir2/apiext/dao/impl/MedicationAdministrationHibernateIntegrationTest.java
+++ b/api/src/test/java/org/openmrs/module/fhir2/apiext/dao/impl/MedicationAdministrationHibernateIntegrationTest.java
@@ -1,0 +1,230 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2.apiext.dao.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Properties;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.openmrs.Provider;
+import org.openmrs.User;
+import org.openmrs.module.ipd.api.model.MedicationAdministration;
+import org.openmrs.module.ipd.api.model.MedicationAdministrationNote;
+import org.openmrs.module.ipd.api.model.MedicationAdministrationPerformer;
+import org.springframework.jdbc.datasource.SimpleDriverDataSource;
+import org.springframework.orm.hibernate5.LocalSessionFactoryBean;
+
+/**
+ * Standalone integration test — no Spring application context — verifying that
+ * {@link MedicationAdministration}, together with its cascaded
+ * {@link MedicationAdministrationPerformer} and {@link MedicationAdministrationNote} collections,
+ * can be persisted and reloaded through Hibernate using the module's HBM XML mappings.
+ *
+ * <h3>Why standalone?</h3>
+ * The OpenMRS test application context (loaded by {@code BaseContextSensitiveTest}) scans
+ * {@code org.openmrs.*} and instantiates all fhir2-api {@code @Component} beans. Those beans
+ * depend on {@code SearchQueryInclude<T>} generic-typed beans that are only available in the full
+ * FHIR2 OMOD context (not in an isolated test classpath). Bootstrapping the Hibernate
+ * {@link SessionFactory} directly — using Spring's {@link LocalSessionFactoryBean} for its JPA
+ * package-scan capability — sidesteps that issue entirely without modifying any production bean
+ * definitions.
+ *
+ * <h3>Schema and test data</h3>
+ * A fresh H2 in-memory database is created once per test class. The URL includes
+ * {@code REFERENTIAL_INTEGRITY=FALSE} so that stub FK references ({@code User} and
+ * {@code Provider} proxies backed by hard-coded IDs) can be written without seeding the entire
+ * OpenMRS reference table set. {@code hbm2ddl.auto=create} generates the full schema from the
+ * combined HBM and JPA entity mappings automatically.
+ *
+ * <h3>Round-trip being tested</h3>
+ * <ol>
+ *   <li>Build entity graph (parent + one performer + one note).</li>
+ *   <li>Persist via {@code session.save()} — {@code cascade="all"} in the HBM XML saves the
+ *       children.</li>
+ *   <li>Flush SQL to the DB and clear the first-level cache.</li>
+ *   <li>Reload by generated PK and assert every mapped field.</li>
+ * </ol>
+ */
+public class MedicationAdministrationHibernateIntegrationTest {
+
+	private static SessionFactory sessionFactory;
+
+	@BeforeClass
+	public static void buildSessionFactory() throws Exception {
+		/*
+		 * H2 in-memory data source.  REFERENTIAL_INTEGRITY=FALSE lets us use
+		 * Hibernate proxy stubs for User and Provider without inserting those rows.
+		 */
+		SimpleDriverDataSource dataSource = new SimpleDriverDataSource(
+		        new org.h2.Driver(),
+		        "jdbc:h2:mem:med_admin_mapping_test;DB_CLOSE_DELAY=-1;REFERENTIAL_INTEGRITY=FALSE",
+		        "sa", "");
+
+		/*
+		 * LocalSessionFactoryBean gives us Spring's packagesToScan capability so that
+		 * JPA-annotated OpenMRS entities (Encounter, Allergy, Condition …) are
+		 * registered alongside the HBM-mapped ones — exactly as the production
+		 * HibernateSessionFactoryBean does in TestingApplicationContext.xml.
+		 * No Spring application context is started, so no fhir2 service beans are
+		 * instantiated and no FHIR2 infrastructure is needed.
+		 */
+		LocalSessionFactoryBean factoryBean = new LocalSessionFactoryBean();
+		factoryBean.setDataSource(dataSource);
+
+		// Core OpenMRS HBM mappings (Patient, Drug, Order, Concept, User, Provider …)
+		factoryBean.setConfigLocations(
+		        new org.springframework.core.io.ClassPathResource("hibernate.cfg.xml"));
+
+		// Module-specific mappings under test
+		factoryBean.setMappingResources(
+		        "MedicationAdministration.hbm.xml",
+		        "MedicationAdministrationPerformer.hbm.xml",
+		        "MedicationAdministrationNote.hbm.xml");
+
+		// JPA-annotated OpenMRS entities (Encounter, Allergy, Condition …)
+		factoryBean.setPackagesToScan("org.openmrs");
+
+		Properties hibernateProps = new Properties();
+		hibernateProps.setProperty("hibernate.dialect", "org.hibernate.dialect.H2Dialect");
+		hibernateProps.setProperty("hibernate.hbm2ddl.auto", "create");
+		hibernateProps.setProperty("hibernate.show_sql", "false");
+		hibernateProps.setProperty("hibernate.cache.use_second_level_cache", "false");
+		hibernateProps.setProperty("hibernate.cache.use_query_cache", "false");
+		hibernateProps.setProperty("hibernate.search.autoregister_listeners", "false");
+		// Required for OpenMRS identity-generator mappings (Hibernate 5 default changed)
+		hibernateProps.setProperty("hibernate.id.new_generator_mappings", "false");
+		factoryBean.setHibernateProperties(hibernateProps);
+
+		factoryBean.afterPropertiesSet();
+		sessionFactory = factoryBean.getObject();
+	}
+
+	@AfterClass
+	public static void closeSessionFactory() {
+		if (sessionFactory != null) {
+			sessionFactory.close();
+		}
+	}
+
+	@Test
+	public void shouldPersistAndReloadMedicationAdministrationWithPerformersAndNotes() {
+		Session session = sessionFactory.openSession();
+		Transaction tx = session.beginTransaction();
+		try {
+			// ── Stub FK references ─────────────────────────────────────────────────
+			// session.load() returns a Hibernate proxy carrying the given PK.
+			// Hibernate writes only the PK to the FK column; it never loads the actual
+			// row, so these stubs work even though the user / provider tables are empty
+			// (REFERENTIAL_INTEGRITY=FALSE on the H2 URL).
+			User creator = session.load(User.class, 1);
+			Provider provider = session.load(Provider.class, 1);
+
+			// ── Build performer ────────────────────────────────────────────────────
+			MedicationAdministrationPerformer performer = new MedicationAdministrationPerformer();
+			performer.setActor(provider);
+			performer.setCreator(creator);
+			performer.setDateCreated(new Date());
+			performer.setVoided(false);
+
+			// ── Build note ─────────────────────────────────────────────────────────
+			MedicationAdministrationNote note = new MedicationAdministrationNote();
+			note.setAuthor(provider);
+			note.setRecordedTime(new Date());
+			note.setText("Patient tolerated medication well");
+			note.setCreator(creator);
+			note.setDateCreated(new Date());
+			note.setVoided(false);
+
+			// ── Build parent entity ────────────────────────────────────────────────
+			MedicationAdministration medAdmin = new MedicationAdministration();
+			medAdmin.setStatus(
+			    org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.COMPLETED);
+			medAdmin.setAdministeredDateTime(new Date());
+			medAdmin.setDose(500.0);
+			medAdmin.setDosingInstructions("Take with food");
+			medAdmin.setPerformers(new HashSet<>(Collections.singleton(performer)));
+			medAdmin.setNotes(new HashSet<>(Collections.singleton(note)));
+			medAdmin.setCreator(creator);
+			medAdmin.setDateCreated(new Date());
+			medAdmin.setVoided(false);
+
+			// ── Persist (cascade="all" saves performer and note automatically) ─────
+			Integer savedId = (Integer) session.save(medAdmin);
+
+			// Flush SQL to the DB, then evict the first-level cache so the subsequent
+			// get() must issue a SELECT rather than returning the in-memory instance.
+			session.flush();
+			session.clear();
+
+			// ── Reload from the database ───────────────────────────────────────────
+			MedicationAdministration retrieved =
+			        session.get(MedicationAdministration.class, savedId);
+
+			// ── Assert: top-level scalar fields ────────────────────────────────────
+			assertNotNull("Reloaded entity must not be null", retrieved);
+			assertNotNull("UUID must have been auto-generated and persisted",
+			    retrieved.getUuid());
+			assertEquals(
+			    "Status enum must survive the COMPLETED → VARCHAR → COMPLETED round-trip",
+			    org.hl7.fhir.r4.model.MedicationAdministration.MedicationAdministrationStatus.COMPLETED,
+			    retrieved.getStatus());
+			assertEquals("Dose round-trip failed", 500.0, retrieved.getDose(), 0.001);
+			assertEquals("DosingInstructions round-trip failed",
+			    "Take with food", retrieved.getDosingInstructions());
+
+			// ── Assert: performers collection (one-to-many, cascade="all") ─────────
+			assertNotNull("Performers collection must not be null after reload",
+			    retrieved.getPerformers());
+			assertEquals("Exactly one performer must be reloaded",
+			    1, retrieved.getPerformers().size());
+			MedicationAdministrationPerformer retrievedPerformer =
+			        retrieved.getPerformers().iterator().next();
+			assertNotNull("Performer PK must be assigned by the identity generator",
+			    retrievedPerformer.getMedicationAdministrationPerformerId());
+			// getProviderId() reads the PK from the Hibernate proxy identity without
+			// triggering a DB load, confirming the actor_id FK column was written correctly.
+			assertEquals("Performer actor_id FK must match the stub provider id",
+			    Integer.valueOf(1), retrievedPerformer.getActor().getProviderId());
+
+			// ── Assert: notes collection (one-to-many, cascade="all") ─────────────
+			assertNotNull("Notes collection must not be null after reload",
+			    retrieved.getNotes());
+			assertEquals("Exactly one note must be reloaded",
+			    1, retrieved.getNotes().size());
+			MedicationAdministrationNote retrievedNote =
+			        retrieved.getNotes().iterator().next();
+			assertNotNull("Note PK must be assigned by the identity generator",
+			    retrievedNote.getMedicationAdministrationNoteId());
+			assertEquals("Note text must survive the round-trip",
+			    "Patient tolerated medication well", retrievedNote.getText());
+			assertEquals("Note author_id FK must match the stub provider id",
+			    Integer.valueOf(1), retrievedNote.getAuthor().getProviderId());
+
+			tx.commit();
+		}
+		catch (Exception e) {
+			tx.rollback();
+			throw e;
+		}
+		finally {
+			session.close();
+		}
+	}
+}

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -3,9 +3,28 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
-  		    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-  		    http://www.springframework.org/schema/context
-  		    http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+                           http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context
+                           http://www.springframework.org/schema/context/spring-context.xsd">
 
+    <bean id="sessionFactory" class="org.openmrs.api.db.hibernate.HibernateSessionFactoryBean">
+        <property name="configLocations">
+            <list>
+                <value>classpath:hibernate.cfg.xml</value>
+            </list>
+        </property>
+        <property name="mappingResources">
+            <list>
+                <value>MedicationAdministration.hbm.xml</value>
+                <value>MedicationAdministrationPerformer.hbm.xml</value>
+                <value>MedicationAdministrationNote.hbm.xml</value>
+            </list>
+        </property>
+        <property name="packagesToScan">
+            <list>
+                <value>org.openmrs</value>
+            </list>
+        </property>
+    </bean>
 
 </beans>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -17,5 +17,11 @@
 	</require_modules>
 
 	<activator>org.openmrs.module.fhir2.apiext.MedicationAdministrationActivator</activator>
+
+	<mappingFiles>
+		MedicationAdministration.hbm.xml
+		MedicationAdministrationPerformer.hbm.xml
+		MedicationAdministrationNote.hbm.xml
+	</mappingFiles>
 </module>
 

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -3,8 +3,8 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-  		    http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-  		    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+  		    http://www.springframework.org/schema/beans/spring-beans.xsd
+  		    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:component-scan base-package="org.openmrs.module.fhir2.apiext"/>
 	<context:annotation-config />


### PR DESCRIPTION
This PR refactors the way of defining models through Hibernate XML mappings rather than the use of Entity annotations. This is needed for IPD module to load properly in OpenMRS 2.6.x version.

## Summary
The IPD module's `Slot` entity has a JPA `@OneToOne` relationship to `MedicationAdministration`, which is defined in a separate module (`openmrs-module-medicationadministration`). On 2.5.x this worked. On 2.6.x it doesn't — and the reason is subtle.

`MedicationAdministration` extends `BaseFormRecordableOpenmrsData`, a class introduced in OpenMRS 2.6.x. This base class is annotated with `@MappedSuperclass` but lives in a mixed mapping context where OpenMRS core entities are registered through traditional `hbm.xml` files rather than JPA annotations.

When the IPD module declares `<packagesWithMappedClasses>`, Hibernate's annotation processor scans the package and finds the `MedicationAdministration` class (visible through the module classloader since IPD depends on medication-administration). However, the annotation processor cannot "categorize" it — it sees the `@Entity` annotation but cannot determine how the class fits into the mapping hierarchy because its superclass chain crosses the boundary between annotation-mapped and XML-mapped worlds.

Hibernate logs this as:

```
Encountered a non-categorized annotated class [MedicationAdministration]; ignoring
```

The entity is silently skipped. Then when Hibernate processes `Slot` and tries to resolve the `@OneToOne` reference to `MedicationAdministration`, it fails because that entity was never registered. The `SessionFactory` build fails, returns null, and every bean in the system that depends on it — including core services like `adminService`, `conceptService`, etc. — fails to initialize. The entire Spring context collapses.

## The Fix

### Medication Administration Module

Replace JPA annotations with Hibernate XML mappings (`hbm.xml` files) for all three entity classes: `MedicationAdministration`, `MedicationAdministrationPerformer`, and `MedicationAdministrationNote`.

The `@Entity`, `@Table`, `@Column`, `@JoinColumn`, `@ManyToOne`, `@OneToMany`, `@Enumerated`, `@Id`, and `@GeneratedValue` annotations are removed from the Java classes. The equivalent mapping information is expressed in `.hbm.xml` files instead.

These mapping files are registered through the `<mappingFiles>` element in the module's `config.xml`. This tells the OpenMRS module framework to add them directly to the Hibernate `SessionFactory` configuration — bypassing the annotation processor entirely. The entities go straight into Hibernate's mapping metadata through the XML pathway, which has no issues with the `BaseFormRecordableOpenmrsData` superclass.

The Spring XML schema references are also updated from versioned (`spring-beans-3.0.xsd`) to versionless (`spring-beans.xsd`) for compatibility with Spring 5.3.